### PR TITLE
Fix SQLite Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ more information on how to properly set the connection URL from an environment v
 
 ### Sqlite config
 
-If you are using the sqlite adapter only the `DATABASE_NAME` env is required.
+If you are using the sqlite adapter only the `DATABASE_NAME` env is required. The database file will be written to the
+`/tmp` directory.
 
 Make sure to use only the name: 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ export default defineConfig({
     environment: 'prisma', // Required
     environmentOptions: {
       adapter: 'mysql',
-      envFile: '.env.test'
+      envFile: '.env.test',
+      prismaEnvVarName: 'DATABASE_URL'  // Overrides the environment variable used for the Prisma DB connection URL
     }
   }
 })
@@ -46,31 +47,37 @@ export default defineConfig({
 
 ## Environment Options
 
-| Name | Description | Default |
-|:-----|:------------|:--------|
-| adapter | Name database adapter. See [Adapters](#adapters) | `mysql` |
-| envFile | Name of the `.env` file for test suit | `.env.test` |
-| schemaPrefix | Prefix to attach on the database name | |
+| Name             | Description                                                    | Default        |
+|:-----------------|:---------------------------------------------------------------|:---------------|
+| adapter          | Name database adapter. See [Adapters](#adapters)               | `mysql`        |
+| envFile          | Name of the `.env` file for test suit                          | `.env.test`    |
+| schemaPrefix     | Prefix to attach on the database name                          |                |
+| prismaEnvVarName | The environment variable used for the Prisma DB connection URL | `DATABASE_URL` |
 
 ## Database Credentials
 
 The following keys must be present on your `.env.test` file:
 
-| Name | Description | Example |
-|:-----|:------------|:--------|
-| `DATABASE_USER` | Database user credential | `root` |
-| `DATABASE_PASS` | Database user password credential | `root` |
-| `DATABASE_HOST` | Database connection host | `localhost`, `127.0.0.1` |
-| `DATABASE_PORT` | Database connection port | `5432`, `3306` |
-| `DATABASE_NAME` | Database name | `mydb` |
+| Name            | Description                       | Example                  |
+|:----------------|:----------------------------------|:-------------------------|
+| `DATABASE_USER` | Database user credential          | `root`                   |
+| `DATABASE_PASS` | Database user password credential | `root`                   |
+| `DATABASE_HOST` | Database connection host          | `localhost`, `127.0.0.1` |
+| `DATABASE_PORT` | Database connection port          | `5432`, `3306`           |
+| `DATABASE_NAME` | Database name                     | `mydb`                   |
 
-These credentials are necessary to make the `DATABASE_URL` env value to which the prisma connection will be made. See [Prisma database connections](https://www.prisma.io/docs/concepts/database-connectors) for more.
+These credentials are necessary to construct the `DATABASE_URL` env value (can be overridden, see above) to which the 
+prisma connection will be made. 
+See the [Prisma database connections](https://www.prisma.io/docs/reference/database-reference/connection-urls#env) for 
+more information on how to properly set the connection URL from an environment variable.
 
 ### Sqlite config
 
 If you are using the sqlite adapter only the `DATABASE_NAME` env is required.
-Make sure to use only the name: Ex:
-- `DATABASE_NAME=file:/mydb` :heavy_multiplication_x:
+
+Make sure to use only the name: 
+
 - `DATABASE_NAME=mydb` :heavy_check_mark:
-- `DATABASE_NAME=mydb.db` :heavy_check_mark:
-- `DATABASE_NAME=../mydb` :heavy_check_mark:
+- `DATABASE_NAME=file:/mydb` :heavy_multiplication_x:
+- `DATABASE_NAME=mydb.db` :heavy_multiplication_x:
+- `DATABASE_NAME=../mydb` :heavy_multiplication_x:

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,13 +58,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@prisma/engines": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.4.0.tgz",
-      "integrity": "sha512-Fpykccxlt9MHrAs/QpPGpI2nOiRxuLA+LiApgA59ibbf24YICZIMWd3SI2YD+q0IAIso0jCGiHhirAIbxK3RyQ==",
-      "hasInstallScript": true,
-      "peer": true
-    },
     "node_modules/@types/chai": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
@@ -1007,23 +1000,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/prisma": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.4.0.tgz",
-      "integrity": "sha512-l/QKLmLcKJQFuc+X02LyICo0NWTUVaNNZ00jKJBqwDyhwMAhboD1FWwYV50rkH4Wls0RviAJSFzkC2ZrfawpfA==",
-      "hasInstallScript": true,
-      "peer": true,
-      "dependencies": {
-        "@prisma/engines": "4.4.0"
-      },
-      "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1315,12 +1291,6 @@
       "integrity": "sha512-O+NfmkfRrb3uSsTa4jE3WApidSe3N5++fyOVGP1SmMZi4A3BZELkhUUvj5hwmMuNdlpzAZ8iAPz2vmcR7DCFQA==",
       "dev": true,
       "optional": true
-    },
-    "@prisma/engines": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.4.0.tgz",
-      "integrity": "sha512-Fpykccxlt9MHrAs/QpPGpI2nOiRxuLA+LiApgA59ibbf24YICZIMWd3SI2YD+q0IAIso0jCGiHhirAIbxK3RyQ==",
-      "peer": true
     },
     "@types/chai": {
       "version": "4.3.3",
@@ -1870,8 +1840,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
       "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "pg-protocol": {
       "version": "1.5.0",
@@ -1943,15 +1912,6 @@
       "dev": true,
       "requires": {
         "xtend": "^4.0.0"
-      }
-    },
-    "prisma": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.4.0.tgz",
-      "integrity": "sha512-l/QKLmLcKJQFuc+X02LyICo0NWTUVaNNZ00jKJBqwDyhwMAhboD1FWwYV50rkH4Wls0RviAJSFzkC2ZrfawpfA==",
-      "peer": true,
-      "requires": {
-        "@prisma/engines": "4.4.0"
       }
     },
     "pseudomap": {

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -2,6 +2,7 @@ export type PrismaEnvironmentOptions = {
   envFile: string
   schemaPrefix: string
   adapter: 'mysql' | 'psql' | 'sqlite'
+  prismaEnvVarName: string
 }
 
 export type EnvironmentDatabaseCredentials = {

--- a/src/adapters/sqliteAdapter.ts
+++ b/src/adapters/sqliteAdapter.ts
@@ -1,8 +1,7 @@
-import { resolve } from 'path'
 import { promisify } from 'util'
 import { exec } from 'child_process'
-import { readFileSync, rm } from 'fs'
-
+import { rm } from 'fs'
+import { tmpdir } from 'os';
 import { EnvironmentAdapterOptions, EnvironmentDatabaseCredentials, SqliteEnvironmentAdapterOptions } from '../@types'
 
 const execSync = promisify(exec)
@@ -12,31 +11,20 @@ const prismaBinary = './node_modules/.bin/prisma'
 
 export function getConnectionString(databaseCredentials: EnvironmentDatabaseCredentials) {
   const { dbName, dbSchema } = databaseCredentials
-  return `file:./${dbName.replace('.db', '')}_${dbSchema}.db`
+  return `file:${tmpdir()}/${dbName.replace('.db', '')}_${dbSchema}.db`
 }
 
 export async function setupDatabase(_adapterOptions: EnvironmentAdapterOptions) {
-  await execSync(`${prismaBinary} 'db push --skip-generate --force-reset'`)
+  await execSync(`${prismaBinary} db push --skip-generate --force-reset`)
 }
 
 export async function teardownDatabase(adapterOptions: EnvironmentAdapterOptions) {
   const { databaseSchema, databaseName } = adapterOptions as SqliteEnvironmentAdapterOptions
 
-  let prismaFolder = 'prisma'
-
-  const packageJsonPath = process.env?.npm_package_json
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, { encoding: 'utf8' }))
-
-  if (packageJson?.prisma?.schema) {
-    const customPrismaFolder = packageJson.prisma.schema.split('/')
-    customPrismaFolder.pop()
-    prismaFolder = customPrismaFolder.join('/')
-  }
-
-  const databaseFile = resolve(process.cwd(), prismaFolder, `${databaseName.replace('.db', '')}_${databaseSchema}.db`)
+  const databaseFile = `${tmpdir()}/${databaseName.replace('.db', '')}_${databaseSchema}.db`
 
   await rmSync(databaseFile)
-  await rmSync(`${databaseFile}-journal`).catch(() => console.log('Journal file not created'))
+  await rmSync(`${tmpdir()}/${databaseFile}-journal`).catch(() => console.log('Journal file not created'))
 }
 
 export default {

--- a/src/adapters/sqliteAdapter.ts
+++ b/src/adapters/sqliteAdapter.ts
@@ -1,7 +1,7 @@
-import { readFileSync, rm } from 'fs'
 import { resolve } from 'path'
 import { promisify } from 'util'
 import { exec } from 'child_process'
+import { readFileSync, rm } from 'fs'
 
 import { EnvironmentAdapterOptions, EnvironmentDatabaseCredentials, SqliteEnvironmentAdapterOptions } from '../@types'
 
@@ -16,7 +16,7 @@ export function getConnectionString(databaseCredentials: EnvironmentDatabaseCred
 }
 
 export async function setupDatabase(_adapterOptions: EnvironmentAdapterOptions) {
-  await execSync(`${prismaBinary} migrate deploy`)
+  await execSync(`${prismaBinary} 'db push --skip-generate --force-reset'`)
 }
 
 export async function teardownDatabase(adapterOptions: EnvironmentAdapterOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ export default <Environment>{
     const {
       adapter = 'mysql',
       envFile = '.env.test',
-      schemaPrefix = ''
+      schemaPrefix = '',
+      prismaEnvVarName = 'DATABASE_URL'
     } = options as PrismaEnvironmentOptions
 
     if (!Object.keys(supportedAdapters).includes(adapter)) {
@@ -78,8 +79,8 @@ export default <Environment>{
       dbSchema
     })
 
-    process.env.DATABASE_URL = connectionString
-    global.process.env.DATABASE_URL = connectionString
+    process.env[prismaEnvVarName] = connectionString
+    global.process.env[prismaEnvVarName] = connectionString
 
     const adapterOptions = {
       connectionString,


### PR DESCRIPTION
Added the 'prismaEnvVarName' environment option to override the environment variable name used for Prisma connections which is necessary for situations where the variable is not the standard "DATABASE_URL" default. As an example when using PlanteScale as a database provider the connection variable needs to be "PLANETSCALE_PRISMA_DATABASE_URL".

Change the SQLite `setupDatabase` Prisma command to `db push --skip-generate --force-reset` to guarantee that the SQLite is created.

Change the default directory used for SQLite to `/tmp` to support IDE test runners that may not use the same CWD as the project. (WebStorm does weird stuff when running vitest)