### PR TITLE
Adds transformMode required since 0.34.0 Vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ export default defineConfig({
     environmentOptions: {
       adapter: 'mysql',
       envFile: '.env.test',
-      prismaEnvVarName: 'DATABASE_URL'  // Optional
+      prismaEnvVarName: 'DATABASE_URL', // Optional
+      transformMode: 'ssr', // Optional
     }
   }
 })
@@ -54,6 +55,7 @@ export default defineConfig({
 | multiSchema      | Option to support multiple prisma schemas                      | `false`        |
 | schemaPrefix     | Prefix to attach on the database name                          |                |
 | prismaEnvVarName | The environment variable used for the Prisma DB connection URL | `DATABASE_URL` |
+| transformMode    | This value determines how plugins will transform source code   | `ssr`          |
 
 ## Database Credentials
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "vitest-environment-prisma",
-  "version": "0.2.2",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitest-environment-prisma",
-      "version": "0.2.2",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^18.7.23",
         "@types/pg": "^8.6.5",
-        "dotenv": "^16.0.3",
+        "dotenv": "^16.3.1",
         "mysql2": "^2.3.3",
         "pg": "^8.8.0",
         "rimraf": "^3.0.2",
@@ -56,6 +56,51 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.7.1.tgz",
+      "integrity": "sha512-yrVSO/YZOxdeIxcBtZ5BaNqUfPrZkNsAKQIQg36cJKMxj/VYK3Vk5jMKkI+gQLl0KReo1YvX8GWKfV788SELjw==",
+      "peer": true
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.7.1.tgz",
+      "integrity": "sha512-R+Pqbra8tpLP2cvyiUpx+SIKglav3nTCpA+rn6826CThviQ8yvbNG0s8jNpo51vS9FuZO3pOkARqG062vKX7uA==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@prisma/debug": "5.7.1",
+        "@prisma/engines-version": "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5",
+        "@prisma/fetch-engine": "5.7.1",
+        "@prisma/get-platform": "5.7.1"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5.tgz",
+      "integrity": "sha512-dIR5IQK/ZxEoWRBDOHF87r1Jy+m2ih3Joi4vzJRP+FOj5yxCwS2pS5SBR3TWoVnEK1zxtLI/3N7BjHyGF84fgw==",
+      "peer": true
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.7.1.tgz",
+      "integrity": "sha512-9ELauIEBkIaEUpMIYPRlh5QELfoC6pyHolHVQgbNxglaINikZ9w9X7r1TIePAcm05pCNp2XPY1ObQIJW5nYfBQ==",
+      "peer": true,
+      "dependencies": {
+        "@prisma/debug": "5.7.1",
+        "@prisma/engines-version": "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5",
+        "@prisma/get-platform": "5.7.1"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.7.1.tgz",
+      "integrity": "sha512-eDlswr3a1m5z9D/55Iyt/nZqS5UpD+DZ9MooBB3hvrcPhDQrcf9m4Tl7buy4mvAtrubQ626ECtb8c6L/f7rGSQ==",
+      "peer": true,
+      "dependencies": {
+        "@prisma/debug": "5.7.1"
       }
     },
     "node_modules/@types/chai": {
@@ -208,12 +253,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -1000,6 +1048,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prisma": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.7.1.tgz",
+      "integrity": "sha512-ekho7ziH0WEJvC4AxuJz+ewRTMskrebPcrKuBwcNzVDniYxx+dXOGcorNeIb9VEMO5vrKzwNYvhD271Ui2jnNw==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@prisma/engines": "5.7.1"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -1292,6 +1356,50 @@
       "dev": true,
       "optional": true
     },
+    "@prisma/debug": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.7.1.tgz",
+      "integrity": "sha512-yrVSO/YZOxdeIxcBtZ5BaNqUfPrZkNsAKQIQg36cJKMxj/VYK3Vk5jMKkI+gQLl0KReo1YvX8GWKfV788SELjw==",
+      "peer": true
+    },
+    "@prisma/engines": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.7.1.tgz",
+      "integrity": "sha512-R+Pqbra8tpLP2cvyiUpx+SIKglav3nTCpA+rn6826CThviQ8yvbNG0s8jNpo51vS9FuZO3pOkARqG062vKX7uA==",
+      "peer": true,
+      "requires": {
+        "@prisma/debug": "5.7.1",
+        "@prisma/engines-version": "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5",
+        "@prisma/fetch-engine": "5.7.1",
+        "@prisma/get-platform": "5.7.1"
+      }
+    },
+    "@prisma/engines-version": {
+      "version": "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5.tgz",
+      "integrity": "sha512-dIR5IQK/ZxEoWRBDOHF87r1Jy+m2ih3Joi4vzJRP+FOj5yxCwS2pS5SBR3TWoVnEK1zxtLI/3N7BjHyGF84fgw==",
+      "peer": true
+    },
+    "@prisma/fetch-engine": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.7.1.tgz",
+      "integrity": "sha512-9ELauIEBkIaEUpMIYPRlh5QELfoC6pyHolHVQgbNxglaINikZ9w9X7r1TIePAcm05pCNp2XPY1ObQIJW5nYfBQ==",
+      "peer": true,
+      "requires": {
+        "@prisma/debug": "5.7.1",
+        "@prisma/engines-version": "5.7.1-1.0ca5ccbcfa6bdc81c003cf549abe4269f59c41e5",
+        "@prisma/get-platform": "5.7.1"
+      }
+    },
+    "@prisma/get-platform": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.7.1.tgz",
+      "integrity": "sha512-eDlswr3a1m5z9D/55Iyt/nZqS5UpD+DZ9MooBB3hvrcPhDQrcf9m4Tl7buy4mvAtrubQ626ECtb8c6L/f7rGSQ==",
+      "peer": true,
+      "requires": {
+        "@prisma/debug": "5.7.1"
+      }
+    },
     "@types/chai": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
@@ -1410,9 +1518,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "dev": true
     },
     "esbuild": {
@@ -1840,7 +1948,8 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.2.tgz",
       "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "pg-protocol": {
       "version": "1.5.0",
@@ -1912,6 +2021,15 @@
       "dev": true,
       "requires": {
         "xtend": "^4.0.0"
+      }
+    },
+    "prisma": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.7.1.tgz",
+      "integrity": "sha512-ekho7ziH0WEJvC4AxuJz+ewRTMskrebPcrKuBwcNzVDniYxx+dXOGcorNeIb9VEMO5vrKzwNYvhD271Ui2jnNw==",
+      "peer": true,
+      "requires": {
+        "@prisma/engines": "5.7.1"
       }
     },
     "pseudomap": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/node": "^18.7.23",
     "@types/pg": "^8.6.5",
-    "dotenv": "^16.0.3",
+    "dotenv": "^16.3.1",
     "mysql2": "^2.3.3",
     "pg": "^8.8.0",
     "rimraf": "^3.0.2",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -4,6 +4,7 @@ export type PrismaEnvironmentOptions = {
   schemaPrefix: string
   adapter: 'mysql' | 'psql' | 'sqlite'
   prismaEnvVarName: string
+  transformMode: 'ssr' | 'web'
 }
 
 export type EnvironmentDatabaseCredentials = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,14 +17,18 @@ const supportedAdapters = {
 
 export default <Environment>{
   name: 'prisma',
+  transformMode: "ssr",
   async setup(global, options = {}) {
     const {
       adapter = 'mysql',
       envFile = '.env.test',
       multiSchema = false,
       schemaPrefix = '',
-      prismaEnvVarName = 'DATABASE_URL'
+      prismaEnvVarName = 'DATABASE_URL',
+      transformMode
     } = options as PrismaEnvironmentOptions
+    
+    this.transformMode = transformMode;
 
     if (!Object.keys(supportedAdapters).includes(adapter)) {
       throw new Error('Unsupported database adapter value.\n\nSee supported adapters in https://github.com/carlos8v/vitest-environment-prisma#adapters.')


### PR DESCRIPTION
Starting from version 0.34.0, **Vitest** now mandates the presence of the `transformMode` option in the environment object. This option must be assigned a value of either "ssr" or "web." The chosen value dictates the behavior of how plugins transform source code.

When `transformMode` is set to "ssr," plugin hooks will receive `ssr: true` during the process of transforming or resolving files. Conversely, if the mode is set to "web," the `ssr` property will be set to false.

The default setting for this change establishes the `transformMode` value as "ssr." However, this value can be modified in the configuration file to accommodate specific requirements. This pull request also includes updates to the types and README to align with these changes.
